### PR TITLE
Redesign tab bar as floating pill, improve donation flow and iOS 26 s…

### DIFF
--- a/MAS-SI-APP/ios/MASStatenIsland.xcodeproj/project.pbxproj
+++ b/MAS-SI-APP/ios/MASStatenIsland.xcodeproj/project.pbxproj
@@ -172,8 +172,8 @@
 				LastUpgradeCheck = 1130;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = 65XQ88ASFM;
 						LastSwiftMigration = 1250;
-						DevelopmentTeam = "65XQ88ASFM";
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -402,7 +402,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "Mas-SI-Glass";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = MASStatenIsland/MASStatenIsland.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 65XQ88ASFM;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -428,9 +431,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
-				DEVELOPMENT_TEAM = "65XQ88ASFM";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 			};
 			name = Debug;
 		};
@@ -441,7 +441,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "Mas-SI-Glass";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = MASStatenIsland/MASStatenIsland.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 65XQ88ASFM;
 				INFOPLIST_FILE = MASStatenIsland/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -461,9 +464,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
-				DEVELOPMENT_TEAM = "65XQ88ASFM";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 			};
 			name = Release;
 		};

--- a/MAS-SI-APP/src/app/(user)/_layout.tsx
+++ b/MAS-SI-APP/src/app/(user)/_layout.tsx
@@ -1,4 +1,4 @@
-import { Tabs, Redirect, useSegments, router } from "expo-router";
+import { Tabs, Redirect, useSegments, router, useRouter } from "expo-router";
 import * as Animatable from 'react-native-animatable';
 import { Pressable, TouchableOpacity, Modal, StyleSheet, Platform, useWindowDimensions, Alert } from "react-native";
 import { useEffect, useRef, useState } from "react";
@@ -22,6 +22,8 @@ import AccountModal from '../../components/AccountModal';
 import ClassicTabBar from '../../components/ClassicTabBar';
 // import TutorialOverlay from "@/src/components/TutorialOverlay";
 import { NativeTabs, Label, Icon } from 'expo-router/unstable-native-tabs';
+import { Icon as PaperIcon } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { PersonalizedAccount } from '@/src/components/PersonalizedAccount';
 import { CreateProfilePopup } from '@/src/components/CreateProfilePopup';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
@@ -187,6 +189,88 @@ let _lastShownWhatsNewVersion = false;
 //   );
 // }
 
+const PILL_TABS = [
+  { name: 'menu', title: 'Home', icon: 'home' },
+  { name: 'myPrograms', title: 'My Library', icon: 'book-outline' },
+  { name: 'prayersTable', title: 'Prayer Times', icon: 'clock-outline' },
+  { name: 'more', title: 'More', icon: 'chat-processing-outline' },
+] as const;
+
+const PillTabBar = ({ activeTab }: { activeTab: string }) => {
+  const insets = useSafeAreaInsets();
+  const pillRouter = useRouter();
+
+  return (
+    <View style={{
+      position: 'absolute',
+      left: 12,
+      right: 12,
+      bottom: Math.max(insets.bottom - 8, 4),
+    }}>
+      <BlurView
+        intensity={40}
+        tint="light"
+        style={{
+          borderRadius: 28,
+          overflow: 'hidden',
+        }}
+      >
+        <View style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-around',
+          paddingVertical: 8,
+          paddingHorizontal: 4,
+          minHeight: 56,
+          backgroundColor: 'rgba(255,255,255,0.25)',
+        }}>
+          {PILL_TABS.map((tab) => {
+            const isFocused = activeTab === tab.name;
+            return (
+              <Pressable
+                key={tab.name}
+                onPress={() => {
+                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                  pillRouter.navigate(`/(user)/${tab.name}` as any);
+                }}
+                style={{
+                  flex: 1,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  paddingVertical: 4,
+                }}
+              >
+                {isFocused && (
+                  <View style={{
+                    position: 'absolute',
+                    top: 0, bottom: 0, left: 6, right: 6,
+                    backgroundColor: 'rgba(13, 80, 157, 0.1)',
+                    borderRadius: 16,
+                  }} />
+                )}
+                <PaperIcon
+                  source={tab.icon}
+                  size={22}
+                  color={isFocused ? '#0D509D' : '#8E8E93'}
+                />
+                <Text style={{
+                  fontSize: 10,
+                  textAlign: 'center',
+                  color: isFocused ? '#0D509D' : '#8E8E93',
+                  fontWeight: isFocused ? '600' : '400',
+                  marginTop: 2,
+                }}>
+                  {tab.title}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      </BlurView>
+    </View>
+  );
+};
+
 // Notification Badge Component with count (no animation)
 const NotificationBadge = ({ count = 1 }: { count?: number }) => {
   const { width: screenWidth } = useWindowDimensions();
@@ -262,6 +346,8 @@ const UserLayoutContent = () => {
   const whatsNewCheckedRef = useRef(false);
   const notificationAlertShownRef = useRef(false);
   const { isEnabled: notificationsEnabled, requestPermission } = useNotifications();
+  const iOSVersion = Platform.OS === 'ios' ? parseInt(String(Platform.Version), 10) : 0;
+  const useNativeTabBar = Platform.OS === 'ios' && iOSVersion >= 26;
 
   // Check if user needs to see What's New screen — only show once ever; if they've already dismissed it before, don't show again on updates
   useEffect(() => {
@@ -508,42 +594,60 @@ const UserLayoutContent = () => {
     return <Redirect href={'/(auth)/GreetingScreen'} />;
   }
 
+  const activeTab = segments[1] || 'menu';
+
   return (
     <BottomSheetModalProvider>
-      <NativeTabs>
-        {/* {TabArray.map((tab, i) => (
-          <NativeTabs.Trigger key={i} name={`${tab.name}`} >
-            <Label>{tab.title}</Label>
-            <Icon sf={tab.icon as any} drawable="custom_android_drawable" />
+      {useNativeTabBar ? (
+        <NativeTabs>
+          <NativeTabs.Trigger name="menu">
+            <Label>Home</Label>
+            <Icon sf="house.fill" drawable="custom_android_drawable" />
           </NativeTabs.Trigger>
-        ))} */}
-        <NativeTabs.Trigger name="menu">
-          <Label>Home</Label>
-          <Icon sf="house.fill" drawable="custom_android_drawable" />
-        </NativeTabs.Trigger>
-        <NativeTabs.Trigger name="myPrograms">
-          <Label>My Library</Label>
-          <Icon sf="book" drawable="custom_android_drawable" />
-        </NativeTabs.Trigger>
-        <NativeTabs.Trigger name="prayersTable">
-          <Label>Prayer Times</Label>
-          <Icon sf="clock" drawable="custom_android_drawable" />
-        </NativeTabs.Trigger>
-        <NativeTabs.Trigger name="more">
-          <Label>More</Label>
-          <Icon sf="ellipsis.bubble.fill" drawable="custom_android_drawable" />
-        </NativeTabs.Trigger>
-      </NativeTabs>
+          <NativeTabs.Trigger name="myPrograms">
+            <Label>My Library</Label>
+            <Icon sf="book" drawable="custom_android_drawable" />
+          </NativeTabs.Trigger>
+          <NativeTabs.Trigger name="prayersTable">
+            <Label>Prayer Times</Label>
+            <Icon sf="clock" drawable="custom_android_drawable" />
+          </NativeTabs.Trigger>
+          <NativeTabs.Trigger name="more">
+            <Label>More</Label>
+            <Icon sf="ellipsis.bubble.fill" drawable="custom_android_drawable" />
+          </NativeTabs.Trigger>
+        </NativeTabs>
+      ) : (
+        <>
+          <NativeTabs
+            backgroundColor="transparent"
+            blurEffect="none"
+            shadowColor="transparent"
+            disableTransparentOnScrollEdge
+            iconColor={{ default: 'transparent', selected: 'transparent' }}
+            labelStyle={{ default: { color: 'transparent' }, selected: { color: 'transparent' } }}
+          >
+            <NativeTabs.Trigger name="menu">
+              <Label>Home</Label>
+              <Icon sf="house.fill" drawable="custom_android_drawable" />
+            </NativeTabs.Trigger>
+            <NativeTabs.Trigger name="myPrograms">
+              <Label>My Library</Label>
+              <Icon sf="book" drawable="custom_android_drawable" />
+            </NativeTabs.Trigger>
+            <NativeTabs.Trigger name="prayersTable">
+              <Label>Prayer Times</Label>
+              <Icon sf="clock" drawable="custom_android_drawable" />
+            </NativeTabs.Trigger>
+            <NativeTabs.Trigger name="more">
+              <Label>More</Label>
+              <Icon sf="ellipsis.bubble.fill" drawable="custom_android_drawable" />
+            </NativeTabs.Trigger>
+          </NativeTabs>
 
-      {/* Complete profile bottom sheet - moved to more/index.tsx */}
-
-      {/* Create Profile popup for guest users - DISABLED */}
-      {/* {showGuestPopup && (
-        <CreateProfilePopup
-          ref={guestPopupRef}
-          onDismiss={handleGuestPopupDismiss}
-        />
-      )} */}
+          <PillTabBar activeTab={activeTab} />
+        </>
+      )}
 
       {/* Enhanced Badge indicator with notification count */}
       {notificationCount > 0 && (

--- a/MAS-SI-APP/src/app/(user)/more/BusinessAds.tsx
+++ b/MAS-SI-APP/src/app/(user)/more/BusinessAds.tsx
@@ -43,9 +43,9 @@ type FormField = {
 }
 
 const DURATION_OPTIONS = [
-    { value: 'Monthly Subscription', price: '$50/mo', priceInCents: 5000, description: 'Auto-renews monthly', isSubscription: true, priceId: 'plan_TfNqBwd94S8YT5' },
-    { value: '3 Months', price: '$135', priceInCents: 13500, description: 'Save 10%', isSubscription: false },
-    { value: '1 Year', price: '$480', priceInCents: 48000, description: 'Best value - Save 20%', isSubscription: false },
+    { value: 'Monthly Subscription (Auto-Renewal)', price: '$50/mo', priceInCents: 5000, description: 'Monthly donation that automatically renews until canceled', isSubscription: true, priceId: 'plan_TfNqBwd94S8YT5' },
+    { value: '3 Months', price: '$135', priceInCents: 13500, description: '3-month donation (save 10%)', isSubscription: false },
+    { value: '1 Year', price: '$480', priceInCents: 48000, description: '1-year donation (save 20%)', isSubscription: false },
 ]
 
 const ONBOARDING_FEE_CENTS = 10000 // $100 onboarding fee for first-time advertisers
@@ -724,8 +724,27 @@ const BusinessAds = () => {
                 padding: 20,
             }}>
                 <Text style={{ fontSize: 16, color: '#374151', lineHeight: 24 }}>
-                    By donating <Text style={{ fontWeight: '700', color: '#111827' }}>$50 a month</Text> to the community, you get your business advertised to <Text style={{ fontWeight: '700', color: '#111827' }}>3,000+ community members</Text>.
+                    By donating <Text style={{ fontWeight: '700', color: '#111827' }}>$50 a month</Text> to the community, you get your business advertised through the app to <Text style={{ fontWeight: '700', color: '#111827' }}>3,000+ community members</Text>.
                 </Text>
+                <Text style={{ fontSize: 14, color: '#6B7280', lineHeight: 20, marginTop: 8 }}>
+                    A one-time <Text style={{ fontWeight: '700', color: '#111827' }}>$100 onboarding donation fee</Text> applies.
+                </Text>
+            </View>
+
+            {/* Mock Ad Preview */}
+            <View style={{ marginTop: 18 }}>
+                <Text style={{ fontSize: 14, fontWeight: '600', color: '#374151', marginBottom: 10 }}>
+                    Example of your in-app ad
+                </Text>
+                <BusinessAdPreview
+                    businessName="Your Business Name"
+                    address="123 Main St"
+                    city="Staten Island"
+                    state="NY"
+                    phoneNumber="(555) 555-5555"
+                    email="contact@yourbusiness.com"
+                    compact
+                />
             </View>
         </>
     )

--- a/MAS-SI-APP/src/app/(user)/myPrograms/PlaylistIndex.tsx
+++ b/MAS-SI-APP/src/app/(user)/myPrograms/PlaylistIndex.tsx
@@ -3,6 +3,7 @@ import { Link, Stack, useRouter } from 'expo-router'
 import React, { useRef, useState } from 'react'
 import { Ionicons } from '@expo/vector-icons'
 import { TouchableOpacity } from 'react-native-gesture-handler'
+import { BlurView } from 'expo-blur'
 import { useAuth } from "@/src/providers/AuthProvider"
 import { LinearGradient } from 'expo-linear-gradient'
 import Animated, { FadeInDown, FadeInUp } from 'react-native-reanimated'
@@ -202,13 +203,17 @@ const PlaylistIndex = () => {
           headerTransparent: true,
           headerShadowVisible: false,
           headerLeft: () => (
-            <TouchableOpacity 
-              onPress={() => router.back()}
-              activeOpacity={0.5}
-              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-            >
-              <Ionicons name="chevron-back" size={28} color="#000000" />
-            </TouchableOpacity>
+            <View style={{ width: 40, height: 40, borderRadius: 20, overflow: 'hidden' }}>
+              <BlurView intensity={40} tint="light" style={StyleSheet.absoluteFill} />
+              <TouchableOpacity 
+                onPress={() => router.back()}
+                activeOpacity={0.5}
+                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                style={{ width: 40, height: 40, alignItems: 'center', justifyContent: 'center' }}
+              >
+                <Ionicons name="chevron-back" size={22} color="#000000" />
+              </TouchableOpacity>
+            </View>
           ),
         }} 
       />

--- a/MAS-SI-APP/src/components/ClassicTabBar.tsx
+++ b/MAS-SI-APP/src/components/ClassicTabBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { View, Text, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
 import Animated, {
     useAnimatedStyle,
     useSharedValue,
@@ -8,72 +8,47 @@ import Animated, {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import { Icon } from 'react-native-paper';
+import { BlurView } from 'expo-blur';
 import * as Haptics from 'expo-haptics';
 import TabArray from '@/src/lib/tabs';
 
-const TAB_COUNT = TabArray.length;
+const SF_TO_MATERIAL: Record<string, string> = {
+    'house.fill': 'home',
+    'book': 'book-outline',
+    'clock': 'clock-outline',
+    'ellipsis.bubble.fill': 'chat-processing-outline',
+};
 
-// Spring animation config - subtle and smooth
 const SPRING_CONFIG = {
     damping: 20,
     stiffness: 200,
 };
 
-// Colors - clean and classic
-const ACTIVE_COLOR = '#007AFF'; // iOS blue
-const INACTIVE_COLOR = '#8E8E93'; // iOS gray
-const BACKGROUND_COLOR = '#FFFFFF';
-const BORDER_COLOR = '#E5E5E5';
+const ACTIVE_COLOR = '#0D509D';
+const INACTIVE_COLOR = '#8E8E93';
 
 const ClassicTabBar = ({ state, descriptors, navigation }: BottomTabBarProps) => {
     const insets = useSafeAreaInsets();
-    const containerWidth = useSharedValue(0);
 
-    // Animated values for active indicator position
-    const indicatorPosition = useSharedValue(0);
-
-    // Animated values for icon scales
     const iconScale0 = useSharedValue(1);
     const iconScale1 = useSharedValue(1);
     const iconScale2 = useSharedValue(1);
     const iconScale3 = useSharedValue(1);
     const iconScales = [iconScale0, iconScale1, iconScale2, iconScale3];
 
-    // Update animations when route changes
     useEffect(() => {
-        // Filter to only visible routes (those in TabArray)
         const visibleRoutes = state.routes.filter(route =>
             TabArray.some(tab => tab.name === route.name)
         );
-        const visibleIndex = visibleRoutes.findIndex(route =>
-            state.routes[state.index]?.name === route.name
-        );
-
-        // Calculate active indicator position
-        if (containerWidth.value > 0 && visibleIndex >= 0) {
-            const tabWidth = containerWidth.value / visibleRoutes.length;
-            const targetPosition = visibleIndex * tabWidth + tabWidth / 2;
-            indicatorPosition.value = withSpring(targetPosition, SPRING_CONFIG);
-        }
-
-        // Update icon scales - only for visible tabs
         visibleRoutes.forEach((route, index) => {
             const actualIndex = state.routes.findIndex(r => r.key === route.key);
             const isActive = state.index === actualIndex;
             if (iconScales[index]) {
-                iconScales[index].value = withSpring(isActive ? 1.05 : 1, SPRING_CONFIG);
+                iconScales[index].value = withSpring(isActive ? 1.08 : 1, SPRING_CONFIG);
             }
         });
     }, [state.index]);
 
-    // Animated style for active indicator dot
-    const indicatorStyle = useAnimatedStyle(() => {
-        return {
-            transform: [{ translateX: indicatorPosition.value - 4 }], // 4 is half of dot width (8/2)
-        };
-    });
-
-    // Animated styles for icon scales
     const iconStyle0 = useAnimatedStyle(() => ({ transform: [{ scale: iconScale0.value }] }));
     const iconStyle1 = useAnimatedStyle(() => ({ transform: [{ scale: iconScale1.value }] }));
     const iconStyle2 = useAnimatedStyle(() => ({ transform: [{ scale: iconScale2.value }] }));
@@ -81,185 +56,149 @@ const ClassicTabBar = ({ state, descriptors, navigation }: BottomTabBarProps) =>
     const iconStyles = [iconStyle0, iconStyle1, iconStyle2, iconStyle3];
 
     const handlePress = (route: any, visibleIndex: number, onPress: () => void) => {
-        // Light haptic feedback
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-
-        // Subtle press animation
         if (iconScales[visibleIndex]) {
-            iconScales[visibleIndex].value = 0.95;
-            iconScales[visibleIndex].value = withSpring(1.05, SPRING_CONFIG);
+            iconScales[visibleIndex].value = 0.92;
+            iconScales[visibleIndex].value = withSpring(1.08, SPRING_CONFIG);
         }
-
-        // Call the original onPress handler from the descriptor
         onPress();
     };
 
+    const totalHeight = 56 + Math.max(insets.bottom - 8, 4) + 12;
+
     return (
-        <View
-            style={[
-                styles.container,
-                {
-                    paddingBottom: insets.bottom,
-                },
-            ]}
-        >
-            {/* Top Border */}
-            <View style={styles.borderTop} />
+        <View style={{ height: totalHeight }}>
+            <View style={[styles.wrapper, { paddingBottom: Math.max(insets.bottom - 8, 4) }]}>
+                <View style={styles.pill}>
+                <BlurView
+                    intensity={90}
+                    tint="systemChromeMaterialLight"
+                    style={[StyleSheet.absoluteFill, { borderRadius: 28 }]}
+                />
+                <View style={styles.pillOverlay} />
+                <View style={styles.tabsContainer}>
+                    {state.routes
+                        .filter(route => TabArray.some(tab => tab.name === route.name))
+                        .map((route, visibleIndex) => {
+                            const { options } = descriptors[route.key];
+                            const actualIndex = state.routes.findIndex(r => r.key === route.key);
+                            const isFocused = state.index === actualIndex;
+                            const tabItem = TabArray.find(tab => tab.name === route.name);
 
-            {/* Active Indicator Dot */}
-            <Animated.View
-                style={[styles.indicator, indicatorStyle]}
-                pointerEvents="none"
-            />
+                            if (!tabItem) return null;
 
-            {/* Tabs Container */}
-            <View
-                style={styles.tabsContainer}
-                onLayout={(event) => {
-                    const width = event.nativeEvent.layout.width;
-                    containerWidth.value = width;
+                            const iconStyle = iconStyles[visibleIndex] || iconStyles[0];
+                            const iconColor = isFocused ? ACTIVE_COLOR : INACTIVE_COLOR;
+                            const textColor = isFocused ? ACTIVE_COLOR : INACTIVE_COLOR;
 
-                    // Filter to only visible routes (those in TabArray)
-                    const visibleRoutes = state.routes.filter(route =>
-                        TabArray.some(tab => tab.name === route.name)
-                    );
+                            const onPress = () => {
+                                const event = navigation.emit({
+                                    type: 'tabPress',
+                                    target: route.key,
+                                    canPreventDefault: true,
+                                });
+                                if (!event.defaultPrevented) {
+                                    navigation.navigate(route.name);
+                                }
+                            };
 
-                    // Find the visible index of the current route
-                    const currentRoute = state.routes[state.index];
-                    const visibleIndex = currentRoute
-                        ? visibleRoutes.findIndex(route => route.name === currentRoute.name)
-                        : -1;
-
-                    if (visibleIndex >= 0 && visibleRoutes.length > 0) {
-                        const tabWidth = width / visibleRoutes.length;
-                        indicatorPosition.value = visibleIndex * tabWidth + tabWidth / 2;
-                    }
-                }}
-            >
-                {state.routes
-                    .filter(route => {
-                        // Only show routes that exist in TabArray
-                        return TabArray.some(tab => tab.name === route.name);
-                    })
-                    .map((route, visibleIndex) => {
-                        const { options } = descriptors[route.key];
-                        const actualIndex = state.routes.findIndex(r => r.key === route.key);
-                        const isFocused = state.index === actualIndex;
-                        const tabItem = TabArray.find(tab => tab.name === route.name);
-
-                        // Skip if tab item not found (shouldn't happen, but safety check)
-                        if (!tabItem) {
-                            return null;
-                        }
-
-                        const iconStyle = iconStyles[visibleIndex] || iconStyles[0];
-                        const iconColor = isFocused ? ACTIVE_COLOR : INACTIVE_COLOR;
-                        const textColor = isFocused ? ACTIVE_COLOR : INACTIVE_COLOR;
-
-                        // Create onPress handler - use React Navigation's built-in handler
-                        const onPress = () => {
-                            const event = navigation.emit({
-                                type: 'tabPress',
-                                target: route.key,
-                                canPreventDefault: true,
-                            });
-
-                            if (!event.defaultPrevented) {
-                                navigation.navigate(route.name);
-                            }
-                        };
-
-                        return (
-                            <Pressable
-                                key={route.key}
-                                onPress={() => {
-                                    handlePress(route, visibleIndex, onPress);
-                                }}
-                                style={styles.tab}
-                                accessibilityRole="button"
-                                accessibilityState={isFocused ? { selected: true } : {}}
-                                accessibilityLabel={options.tabBarAccessibilityLabel}
-                                testID={`tab-${route.name}`}
-                                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-                            >
-                                <Animated.View style={[styles.iconContainer, iconStyle]}>
-                                    <Icon
-                                        source={tabItem?.icon || 'circle'}
-                                        size={24}
-                                        color={iconColor}
-                                    />
-                                </Animated.View>
-
-                                <Text
-                                    style={[
-                                        styles.label,
-                                        { color: textColor },
-                                    ]}
-                                    numberOfLines={1}
+                            return (
+                                <Pressable
+                                    key={route.key}
+                                    onPress={() => handlePress(route, visibleIndex, onPress)}
+                                    style={styles.tab}
+                                    accessibilityRole="button"
+                                    accessibilityState={isFocused ? { selected: true } : {}}
+                                    accessibilityLabel={options.tabBarAccessibilityLabel}
+                                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
                                 >
-                                    {String(tabItem?.title || options.title || route.name || '')}
-                                </Text>
-                            </Pressable>
-                        );
-                    })
-                    .filter(Boolean)}
+                                    {isFocused && <View style={styles.activeBackground} />}
+                                    <Animated.View style={[styles.iconContainer, iconStyle]}>
+                                        <Icon
+                                            source={SF_TO_MATERIAL[tabItem?.icon || ''] || tabItem?.icon || 'circle'}
+                                            size={22}
+                                            color={iconColor}
+                                        />
+                                    </Animated.View>
+                                    <Text
+                                        style={[
+                                            styles.label,
+                                            {
+                                                color: textColor,
+                                                fontWeight: isFocused ? '600' : '400',
+                                            },
+                                        ]}
+                                        numberOfLines={1}
+                                    >
+                                        {String(tabItem?.title || options.title || route.name || '')}
+                                    </Text>
+                                </Pressable>
+                            );
+                        })
+                        .filter(Boolean)}
+                </View>
+            </View>
             </View>
         </View>
     );
 };
 
 const styles = StyleSheet.create({
-    container: {
-        backgroundColor: BACKGROUND_COLOR,
-        ...Platform.select({
-            ios: {
-                shadowColor: '#000',
-                shadowOffset: { width: 0, height: -2 },
-                shadowOpacity: 0.05,
-                shadowRadius: 8,
-            },
-            android: {
-                elevation: 4,
-            },
-        }),
-    },
-    borderTop: {
-        height: 0.5,
-        backgroundColor: BORDER_COLOR,
-        width: '100%',
-    },
-    indicator: {
+    wrapper: {
         position: 'absolute',
-        top: 8,
-        width: 8,
-        height: 8,
-        borderRadius: 4,
-        backgroundColor: ACTIVE_COLOR,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        paddingHorizontal: 12,
+    },
+    pill: {
+        width: '100%',
+        borderRadius: 28,
+        overflow: 'hidden',
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.12,
+        shadowRadius: 16,
+        elevation: 8,
+    },
+    pillOverlay: {
+        ...StyleSheet.absoluteFillObject,
+        backgroundColor: 'rgba(255, 255, 255, 0.3)',
+        borderRadius: 28,
     },
     tabsContainer: {
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'space-around',
         paddingVertical: 8,
-        minHeight: 60,
+        paddingHorizontal: 4,
+        minHeight: 56,
     },
     tab: {
         flex: 1,
         alignItems: 'center',
         justifyContent: 'center',
         paddingVertical: 4,
+        position: 'relative',
+    },
+    activeBackground: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        left: 6,
+        right: 6,
+        backgroundColor: 'rgba(13, 80, 157, 0.08)',
+        borderRadius: 16,
     },
     iconContainer: {
         alignItems: 'center',
         justifyContent: 'center',
-        marginBottom: 4,
+        marginBottom: 2,
     },
     label: {
-        fontSize: 11,
-        fontWeight: '500',
+        fontSize: 10,
         textAlign: 'center',
     },
 });
 
 export default ClassicTabBar;
-

--- a/MAS-SI-APP/src/components/DonationBottomSheet.tsx
+++ b/MAS-SI-APP/src/components/DonationBottomSheet.tsx
@@ -24,7 +24,7 @@ import * as Haptics from 'expo-haptics';
 import { fetchSavedPaymentMethods, chargeWithSavedCard, getCardBrandDisplayName, SavedPaymentMethod } from '@/src/lib/StripePaySheet';
 
 const { height: SCREEN_HEIGHT, width: SCREEN_WIDTH } = Dimensions.get('window');
-const COLLAPSED_HEIGHT = 390;
+const COLLAPSED_HEIGHT = 320;
 const EXPANDED_HEIGHT = 540;
 const PAYMENT_HEIGHT = 580;
 const PAYMENT_HEIGHT_WITH_KEYBOARD = SCREEN_HEIGHT * 0.92;
@@ -221,6 +221,37 @@ const DonationBottomSheet = forwardRef<DonationBottomSheetRef>((_, ref) => {
     return selectedAmount;
   };
 
+  const fetchDonationPaymentIntent = async (amount: number, saveCard: boolean) => {
+    // Check if user is authenticated
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session) {
+      Alert.alert('Login Required', 'Please log in to make a donation.');
+      return null;
+    }
+
+    // Fetch payment intent from edge function
+    console.log('Calling stripe--checkout with amount:', Math.floor(amount * 100), 'saveCard:', saveCard);
+    const { data, error } = await supabase.functions.invoke('stripe--checkout', {
+      body: { TotalAmount: Math.floor(amount * 100), saveCard }
+    });
+
+    console.log('Edge function response:', JSON.stringify(data, null, 2));
+    console.log('Edge function error:', error);
+
+    if (error || !data?.paymentIntent) {
+      console.log('Payment intent error:', error || data);
+      Alert.alert('Payment Error', 'Failed to initialize payment. Please try again.');
+      return null;
+    }
+
+    // Log the keys for debugging
+    console.log('PaymentIntent client secret (first 20 chars):', data.paymentIntent?.substring(0, 20));
+    console.log('Server publishable key:', data.publishableKey);
+    console.log('Client publishable key:', process.env.STRIPE_PUBLISHABLE_KEY);
+
+    return data.paymentIntent as string;
+  };
+
   // Fetch payment intent and show card input
   const handlePayment = async () => {
     if (isProcessing) return;
@@ -239,36 +270,13 @@ const DonationBottomSheet = forwardRef<DonationBottomSheetRef>((_, ref) => {
     setIsProcessing(true);
 
     try {
-      // Check if user is authenticated
-      const { data: { session } } = await supabase.auth.getSession();
-      if (!session) {
-        Alert.alert('Login Required', 'Please log in to make a donation.');
+      const paymentIntent = await fetchDonationPaymentIntent(amount, saveCardForFuture);
+      if (!paymentIntent) {
         setIsProcessing(false);
         return;
       }
 
-      // Fetch payment intent from edge function
-      console.log('Calling stripe--checkout with amount:', Math.floor(amount * 100), 'saveCard:', saveCardForFuture);
-      const { data, error } = await supabase.functions.invoke('stripe--checkout', { 
-        body: { TotalAmount: Math.floor(amount * 100), saveCard: saveCardForFuture }
-      });
-
-      console.log('Edge function response:', JSON.stringify(data, null, 2));
-      console.log('Edge function error:', error);
-
-      if (error || !data?.paymentIntent) {
-        console.log('Payment intent error:', error || data);
-        Alert.alert('Payment Error', 'Failed to initialize payment. Please try again.');
-        setIsProcessing(false);
-        return;
-      }
-
-      // Log the keys for debugging
-      console.log('PaymentIntent client secret (first 20 chars):', data.paymentIntent?.substring(0, 20));
-      console.log('Server publishable key:', data.publishableKey);
-      console.log('Client publishable key:', process.env.STRIPE_PUBLISHABLE_KEY);
-
-      setPaymentIntentClientSecret(data.paymentIntent);
+      setPaymentIntentClientSecret(paymentIntent);
       
       // Transition to payment view
       if (viewState === 'select') {
@@ -292,6 +300,29 @@ const DonationBottomSheet = forwardRef<DonationBottomSheetRef>((_, ref) => {
     } catch (error) {
       console.log('Payment setup error:', error);
       Alert.alert('Payment Error', 'Something went wrong. Please try again.');
+      setIsProcessing(false);
+    }
+  };
+
+  const handleToggleSaveCardInPayment = async () => {
+    if (isProcessing || confirmLoading) return;
+
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    const nextValue = !saveCardForFuture;
+    setSaveCardForFuture(nextValue);
+
+    if (viewState !== 'payment') return;
+
+    const amount = getFinalAmount();
+    setIsProcessing(true);
+    try {
+      const paymentIntent = await fetchDonationPaymentIntent(amount, nextValue);
+      if (!paymentIntent) {
+        setSaveCardForFuture(!nextValue);
+        return;
+      }
+      setPaymentIntentClientSecret(paymentIntent);
+    } finally {
       setIsProcessing(false);
     }
   };
@@ -774,20 +805,6 @@ const DonationBottomSheet = forwardRef<DonationBottomSheetRef>((_, ref) => {
                 <RNText style={styles.customLinkText}>Enter custom amount</RNText>
               </Pressable>
 
-              {/* Save Card Checkbox */}
-              <Pressable 
-                onPress={() => {
-                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                  setSaveCardForFuture(!saveCardForFuture);
-                }}
-                style={styles.saveCardRow}
-              >
-                <View style={[styles.saveCardCheckbox, saveCardForFuture && styles.saveCardCheckboxChecked]}>
-                  {saveCardForFuture && <Icon source="check" size={14} color="#FFFFFF" />}
-                </View>
-                <RNText style={styles.saveCardText}>Save card for future donations</RNText>
-              </Pressable>
-
               {/* Pay Button */}
               <Pressable
                 style={[styles.donateButton, isProcessing && styles.donateButtonDisabled]}
@@ -859,20 +876,6 @@ const DonationBottomSheet = forwardRef<DonationBottomSheetRef>((_, ref) => {
                   <RNText style={styles.quickChipBtnTextActive}>Other</RNText>
                 </View>
               </View>
-
-              {/* Save Card Checkbox */}
-              <Pressable 
-                onPress={() => {
-                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                  setSaveCardForFuture(!saveCardForFuture);
-                }}
-                style={styles.saveCardRowCustom}
-              >
-                <View style={[styles.saveCardCheckbox, saveCardForFuture && styles.saveCardCheckboxChecked]}>
-                  {saveCardForFuture && <Icon source="check" size={14} color="#FFFFFF" />}
-                </View>
-                <RNText style={styles.saveCardText}>Save card for future donations</RNText>
-              </Pressable>
 
               {/* Review Button */}
               <Pressable
@@ -963,11 +966,9 @@ const DonationBottomSheet = forwardRef<DonationBottomSheetRef>((_, ref) => {
 
                   {/* Save Card + Pay Button */}
                   <Pressable 
-                    onPress={() => {
-                      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                      setSaveCardForFuture(!saveCardForFuture);
-                    }}
+                    onPress={handleToggleSaveCardInPayment}
                     style={styles.saveCardRowPayment}
+                    disabled={isProcessing || confirmLoading}
                   >
                     <View style={[styles.saveCardCheckbox, saveCardForFuture && styles.saveCardCheckboxChecked]}>
                       {saveCardForFuture && <Icon source="check" size={14} color="#FFFFFF" />}
@@ -978,10 +979,10 @@ const DonationBottomSheet = forwardRef<DonationBottomSheetRef>((_, ref) => {
                   <Pressable
                     style={[
                       styles.payButton, 
-                      (!cardComplete || confirmLoading) && styles.payButtonDisabled
+                      (!cardComplete || !paymentIntentClientSecret || confirmLoading || isProcessing) && styles.payButtonDisabled
                     ]}
                     onPress={handleConfirmPayment}
-                    disabled={!cardComplete || confirmLoading}
+                    disabled={!cardComplete || !paymentIntentClientSecret || confirmLoading || isProcessing}
                   >
                     {confirmLoading ? (
                       <ActivityIndicator size="small" color="#FFFFFF" />

--- a/MAS-SI-APP/src/lib/liquidGlass.tsx
+++ b/MAS-SI-APP/src/lib/liquidGlass.tsx
@@ -1,39 +1,42 @@
 import React from 'react';
-import { View, ViewProps } from 'react-native';
+import { View, ViewProps, StyleSheet, Platform } from 'react-native';
+import { BlurView } from 'expo-blur';
 
-// Type for LiquidGlassView props
 type LiquidGlassViewProps = ViewProps & {
   interactive?: boolean;
   effect?: 'clear' | 'regular' | 'strong';
   children?: React.ReactNode;
 };
 
-// Safe import wrapper for @callstack/liquid-glass
-let LiquidGlassViewComponent: React.ComponentType<LiquidGlassViewProps> | null = null;
-let isLiquidGlassSupportedValue = false;
+const isIOS26 = Platform.OS === 'ios' && parseInt(String(Platform.Version), 10) >= 26;
 
-try {
-  const liquidGlass = require('@callstack/liquid-glass');
-  LiquidGlassViewComponent = liquidGlass.LiquidGlassView;
-  // Handle both function and boolean cases
-  if (typeof liquidGlass.isLiquidGlassSupported === 'function') {
-    isLiquidGlassSupportedValue = liquidGlass.isLiquidGlassSupported() ?? false;
-  } else {
-    isLiquidGlassSupportedValue = liquidGlass.isLiquidGlassSupported ?? false;
+let LiquidGlassViewComponent: React.ComponentType<LiquidGlassViewProps> | null = null;
+
+if (isIOS26) {
+  try {
+    const liquidGlass = require('@callstack/liquid-glass');
+    LiquidGlassViewComponent = liquidGlass.LiquidGlassView;
+  } catch (error) {
+    console.warn('@callstack/liquid-glass not available, using fallback');
   }
-} catch (error) {
-  // Module not available, use fallback
-  console.warn('@callstack/liquid-glass not available, using fallback');
 }
 
-// Fallback component that just renders children
-const FallbackView: React.FC<LiquidGlassViewProps> = ({ children, style, ...props }) => (
-  <View style={style} {...props}>
+const BLUR_INTENSITY_MAP: Record<string, number> = {
+  clear: 30,
+  regular: 50,
+  strong: 70,
+};
+
+const FallbackView: React.FC<LiquidGlassViewProps> = ({ children, style, effect = 'regular', ...props }) => (
+  <View style={[style, { overflow: 'hidden', backgroundColor: 'rgba(200,200,200,0.5)' }]} {...props}>
+    <BlurView
+      intensity={BLUR_INTENSITY_MAP[effect] ?? 50}
+      tint="light"
+      style={StyleSheet.absoluteFill}
+    />
     {children}
   </View>
 );
 
-// Export safe versions - ensure fallback is used
-export const LiquidGlassView: React.FC<LiquidGlassViewProps> = (LiquidGlassViewComponent || FallbackView) as React.FC<LiquidGlassViewProps>;
-export const isLiquidGlassSupported = isLiquidGlassSupportedValue;
-
+export const LiquidGlassView: React.FC<LiquidGlassViewProps> = (LiquidGlassViewComponent ?? FallbackView) as React.FC<LiquidGlassViewProps>;
+export const isLiquidGlassSupported = true;

--- a/MAS-SI-APP/src/lib/stripe.ts
+++ b/MAS-SI-APP/src/lib/stripe.ts
@@ -24,6 +24,9 @@ export const initializePaymentSheet = async ( amount : number ) => {
 
     const { error } = await initPaymentSheet({
         merchantDisplayName : 'MAS Staten Island',
+        applePay: {
+            merchantCountryCode: 'US',
+        },
         paymentIntentClientSecret : paymentIntent,
         customerId : customer,
         customerEphemeralKeySecret : ephemeralKey,

--- a/MAS-SI-APP/src/lib/utils.ts
+++ b/MAS-SI-APP/src/lib/utils.ts
@@ -26,15 +26,14 @@ export const getVideoIdFromUrl = (url: string): string | null => {
  */
 export const formatPhoneNumber = (text: string): string => {
   const cleaned = text.replace(/\D/g, '').slice(0, 10);
-  let formatted = '';
-  if (cleaned.length > 0) {
-    formatted = '(' + cleaned.slice(0, 3);
+  if (cleaned.length === 0) {
+    return '';
   }
-  if (cleaned.length >= 3) {
-    formatted += ') ' + cleaned.slice(3, 6);
+  if (cleaned.length <= 3) {
+    return `(${cleaned}`;
   }
-  if (cleaned.length >= 6) {
-    formatted += '-' + cleaned.slice(6, 10);
+  if (cleaned.length <= 6) {
+    return `(${cleaned.slice(0, 3)}) ${cleaned.slice(3)}`;
   }
-  return formatted || cleaned;
+  return `(${cleaned.slice(0, 3)}) ${cleaned.slice(3, 6)}-${cleaned.slice(6, 10)}`;
 };


### PR DESCRIPTION
…upport

- Replace classic tab bar with floating pill-shaped blur tab bar; use native tabs only on iOS 26+
- Only load @callstack/liquid-glass on iOS 26+, use BlurView fallback otherwise
- Extract fetchDonationPaymentIntent and refresh payment intent when save-card is toggled
- Remove save-card checkbox from selection views (keep in payment view only)
- Add Apple Pay merchant config to Stripe payment sheet
- Update business ad pricing descriptions and add mock ad preview
- Add blur-backed rounded back button on playlist screen
- Clean up phone number formatting logic

Made-with: Cursor