### PR TITLE
Fix duplicate notifications when multiple accounts share a device

### DIFF
--- a/MAS-SI-APP/src/providers/NotificationProvider.tsx
+++ b/MAS-SI-APP/src/providers/NotificationProvider.tsx
@@ -64,6 +64,12 @@ export const NotificationProvider = ({ children }: PropsWithChildren) => {
     }
     setPushToken(newToken);
     if (session?.user.id) {
+      await supabase
+        .from('profiles')
+        .update({ push_notification_token: null })
+        .eq('push_notification_token', newToken)
+        .neq('id', session.user.id);
+
       const { error } = await supabase
         .from('profiles')
         .update({ push_notification_token: newToken })


### PR DESCRIPTION
Clear push token from all other profiles before saving it to the current user, ensuring only one profile holds a given device token.

Made-with: Cursor